### PR TITLE
Quick links

### DIFF
--- a/openwink-app/Components/EditQuickLinksModal.tsx
+++ b/openwink-app/Components/EditQuickLinksModal.tsx
@@ -1,0 +1,18 @@
+import { Modal } from "react-native";
+
+interface IEditQuickLinksModal {
+  visible: boolean;
+  close: () => void;
+  initialLinks: [string, string];
+}
+export function EditQuickLinksModal({
+
+}: IEditQuickLinksModal) {
+
+  return (
+    <Modal>
+
+    </Modal>
+  )
+
+}

--- a/openwink-app/Components/EditQuickLinksModal.tsx
+++ b/openwink-app/Components/EditQuickLinksModal.tsx
@@ -1,18 +1,419 @@
-import { Modal } from "react-native";
+import { Text, View, Pressable, Modal, TouchableOpacity } from "react-native";
+import IonIcons from "@expo/vector-icons/Ionicons";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useColorTheme } from "../hooks/useColorTheme";
+import { SearchBarFilter } from "./SearchBarFilter";
+import { ScrollView } from "react-native-gesture-handler";
+import DragList, { DragListRenderItemInfo } from "react-native-draglist";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+
+export type QuickLink = {
+  navigation: {
+    page: string;
+    back: string;
+    backHumanReadable: string;
+  };
+  icon: keyof typeof IonIcons.glyphMap | null;
+  title: string;
+};
+
+type RouteType = QuickLink & { display: string; visible: boolean; };
+
+
+const ROUTES: RouteType[] = [
+  {
+    display: "Settings",
+    icon: "information-circle-outline",
+    title: "System Information",
+    navigation: {
+      back: "Home",
+      backHumanReadable: "Home",
+      page: "Info",
+    },
+    visible: false,
+  },
+  {
+    display: "Settings",
+    icon: "build-outline",
+    title: "Module Settings",
+    navigation: {
+      back: "Home",
+      backHumanReadable: "Home",
+      page: "ModuleSettings",
+    },
+    visible: false,
+  },
+  {
+    display: "Settings",
+    icon: "color-fill-outline",
+    title: "Change App Theme",
+    navigation: {
+      back: "Home",
+      backHumanReadable: "Home",
+      page: "Theme",
+    },
+    visible: false,
+  },
+  {
+    display: "Settings",
+    icon: "document-text-outline",
+    title: "System Terms of Use",
+    navigation: {
+      back: "Home",
+      backHumanReadable: "Home",
+      page: "TermsOfUse",
+    },
+    visible: false,
+  },
+  {
+    display: "Module Settings",
+    icon: "radio-outline",
+    title: "Wave Delay Settings",
+    navigation: {
+      back: "Home",
+      backHumanReadable: "Home",
+      page: "WaveDelaySettings",
+    },
+    visible: false,
+  },
+  {
+    display: "Module Settings",
+    icon: "eye-outline",
+    title: "Sleepy Eye Settings",
+    navigation: {
+      back: "Home",
+      backHumanReadable: "Home",
+      page: "SleepyEyeSettings",
+    },
+    visible: false,
+  },
+  {
+    display: "Module Settings",
+    icon: "speedometer-outline",
+    title: "Set Up Custom Wink Button",
+    navigation: {
+      back: "Home",
+      backHumanReadable: "Home",
+      page: "CustomWinkButton",
+    },
+    visible: false,
+  },
+];
+type Action =
+  | {
+    type: "reorder";
+    moveData: { from: number; to: number };
+  } | {
+    type: "toggle";
+    link: RouteType,
+    moveData?: undefined;
+  };
 
 interface IEditQuickLinksModal {
   visible: boolean;
   close: () => void;
-  initialLinks: [string, string];
+  initialLinks: (QuickLink)[];
+  onUpdateLinks: (updatedLinks: (QuickLink)[]) => void;
 }
-export function EditQuickLinksModal({
 
+export function EditQuickLinksModal({
+  close,
+  initialLinks,
+  onUpdateLinks,
+  visible,
 }: IEditQuickLinksModal) {
+  const mappedInitialLinks = useMemo(() => initialLinks.map(l => l.title), [initialLinks]);
+
+  const { colorTheme, theme } = useColorTheme();
+
+  const [allLinks, setAllLinks] = useState([] as RouteType[]);
+  const [filteredLinks, setFilteredLinks] = useState([] as RouteType[]);
+
+  const onRoutesChange = (
+    data: Action,
+  ) => {
+    if (data.type === "toggle") {
+      setAllLinks(prev => {
+        const mapped = prev.map(l => l.title === data.link.title ? { ...l, visible: !l.visible } : l);
+        return [...mapped.filter(l => l.visible), ...mapped.filter(l => !l.visible)];
+      });
+      setFilteredLinks(prev => {
+        const mapped = prev.map(l => l.title === data.link.title ? { ...l, visible: !l.visible } : l);
+        return [...mapped.filter(l => l.visible), ...mapped.filter(l => !l.visible)];
+      });
+    } else {
+      const filteredItemToMove = filteredLinks[data.moveData.from];
+      const allLinksIndex = allLinks.findIndex(l => l.title === filteredItemToMove.title);
+
+      setAllLinks((prev) => {
+        const spliced = prev.toSpliced(allLinksIndex, 1);
+        // 'OK' since filtered links is either the same or smaller than allLinks
+        spliced.splice(data.moveData.to, 0, filteredItemToMove);
+
+        return [...spliced.filter(l => l.visible), ...spliced.filter(l => !l.visible)];
+      });
+
+      setFilteredLinks((prev) => {
+        const spliced = prev.toSpliced(data.moveData.from, 1);
+        spliced.splice(data.moveData.to, 0, filteredItemToMove);
+
+        return [...spliced.filter(l => l.visible), ...spliced.filter(l => !l.visible)];
+      });
+
+    }
+  }
+
+  const setInitialValues = () => {
+    const mappedLinks = ROUTES.map(r => mappedInitialLinks.includes(r.title) ? { ...r, visible: true } : r);
+    const visible = mappedLinks.filter(r => r.visible);
+    const hidden = mappedLinks.filter(r => !r.visible);
+
+    setAllLinks([...visible, ...hidden]);
+    setFilteredLinks([...visible, ...hidden]);
+  }
+
+  useEffect(() => setInitialValues(), []);
+
+  const resetToStart = () => setInitialValues();
+  const __saveLinksOnClose = () => {
+    onUpdateLinks(allLinks.filter(l => l.visible).map(l => ({ icon: l.icon, navigation: l.navigation, title: l.title })));
+    close();
+  };
+
+  const renderDragItem = useCallback(
+    ({
+      isActive,
+      item,
+      index,
+      onDragEnd,
+      onDragStart,
+    }: DragListRenderItemInfo<RouteType>) => {
+
+
+      return (
+        <View style={{
+          width: "100%",
+          padding: 13,
+          paddingHorizontal: 13,
+          borderRadius: 10,
+          backgroundColor: colorTheme.backgroundSecondaryColor,
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}>
+          <View style={{
+            flexDirection: "row",
+            alignItems: "center",
+            columnGap: 10,
+          }}>
+            <Pressable
+              onPressIn={onDragStart}
+              onPressOut={onDragEnd}
+              hitSlop={10}
+            >
+              {
+                ({ pressed }) => (
+                  <MaterialIcons name="drag-indicator" size={22} color={pressed ? colorTheme.buttonColor : colorTheme.headerTextColor} />
+                )
+              }
+            </Pressable>
+
+            <View style={{ flexDirection: "row", alignItems: "center", columnGap: 7, }}>
+              <IonIcons style={{
+                // padding: 5,
+                height: 30,
+                width: 30,
+                textAlign: "center",
+                verticalAlign: "middle",
+                justifyContent: "center",
+                backgroundColor: `${colorTheme.disabledButtonColor}4D`,
+                borderRadius: 7,
+              }} name={item.icon!} size={19} color={colorTheme.textColor} />
+              <View style={{
+                alignItems: "flex-start",
+              }}>
+                <Text style={{
+                  color: colorTheme.textColor,
+                  fontFamily: "IBMPlexSans_500Medium"
+                }}>
+                  {item.title}
+                </Text>
+                <Text style={{
+                  color: item.visible ? colorTheme.disabledButtonColor : `${colorTheme.disabledButtonColor}80`
+                }}>
+                  {item.visible ? "Visible on home page" : "Hidden from home page"}
+                </Text>
+              </View>
+
+            </View>
+          </View>
+
+          <Pressable
+            hitSlop={20}
+            onPress={() => onRoutesChange({ type: "toggle", link: item })}
+          >
+            {
+              ({ pressed }) => (
+                <IonIcons color={pressed ? colorTheme.buttonColor : colorTheme.textColor} size={19} style={{ marginRight: 5, }} name={item.visible ? "eye-outline" : "eye-off-outline"} />
+              )
+            }
+          </Pressable>
+        </View>
+      )
+
+    }, []);
 
   return (
-    <Modal>
+    <Modal
+      onRequestClose={__saveLinksOnClose}
+      transparent
+      animationType="fade"
+      visible={visible}
+    >
+      <View
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: `${colorTheme.backgroundPrimaryColor}80`,
+        }}
+      >
+        <View
+          style={{
+            alignItems: "center",
+            justifyContent: "flex-start",
+            paddingVertical: 15,
+            paddingHorizontal: 20,
+            rowGap: 15,
+            backgroundColor: colorTheme.backgroundPrimaryColor,
+            width: "90%",
+            borderRadius: 15,
+            boxShadow: "0 3 5px rgba(0, 0, 0, 0.2)"
+          }}
+        >
 
+          <View style={{
+            width: "100%",
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}>
+            <Text
+              style={{
+                fontFamily: "IBMPlexSans_700Bold",
+                color: colorTheme.headerTextColor,
+                fontSize: 22,
+              }}
+            >
+              Edit Quick Links
+            </Text>
+
+            <Pressable
+              hitSlop={10}
+              onPress={__saveLinksOnClose}
+            >
+              {
+                ({ pressed }) => (
+                  <IonIcons name="close-outline" size={25} color={pressed ? colorTheme.buttonColor : colorTheme.headerTextColor} />
+                )
+              }
+            </Pressable>
+          </View>
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "center",
+              columnGap: 10,
+              width: "100%",
+            }}
+          >
+            <Pressable
+              hitSlop={10}
+              onPress={resetToStart}
+            >
+              {
+                ({ pressed }) =>
+                  <View style={{
+                    alignItems: "center",
+                  }}>
+                    <IonIcons name="refresh-outline" color={pressed ? colorTheme.buttonColor : colorTheme.textColor} size={25} />
+                    <Text style={{
+                      marginTop: -2,
+                      fontSize: 10,
+                      color: pressed ? colorTheme.buttonColor : colorTheme.textColor,
+                      fontFamily: "IBMPlexSans_500Medium"
+                    }}>
+                      Reset
+                    </Text>
+                  </View>
+              }
+            </Pressable>
+            <SearchBarFilter
+              useFilters={false}
+              filterables={allLinks}
+              filterTitleText="Filter by page location"
+              searchFilterKey="title"
+              onFilterTextChange={() => { }}
+              placeholderText="Filter by page name..."
+              onFilteredItemsUpdate={(filteredRoutes) => {
+                setFilteredLinks(filteredRoutes);
+              }}
+            />
+          </View>
+
+          <View
+            style={{
+              width: "100%",
+              height: 225
+            }}
+          >
+            <DragList
+              data={filteredLinks}
+              keyExtractor={(item) => `${item.title}-draggable`}
+              renderItem={renderDragItem}
+              scrollEnabled
+              contentContainerStyle={{ rowGap: 12, alignItems: "center" }}
+              onReordered={(from, to) => {
+                onRoutesChange({ type: "reorder", moveData: { from, to } });
+              }}
+            />
+          </View>
+
+          <View style={{
+            width: "100%",
+            marginTop: 10,
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}>
+
+            <Text style={{
+              color: colorTheme.textColor,
+              fontFamily: "IBMPlexSans_500Medium",
+              fontSize: 12,
+            }}>
+              Changes are saved automatically
+            </Text>
+
+            <Text style={{
+              padding: 3,
+              paddingHorizontal: 7,
+              backgroundColor: colorTheme.backgroundSecondaryColor,
+              fontSize: 12,
+              borderRadius: 6,
+              color: colorTheme.textColor,
+
+              fontFamily: "IBMPlexSans_500Medium",
+            }}>
+              {allLinks.filter(r => r.visible).length} of {ROUTES.length} visible
+            </Text>
+          </View>
+
+        </View>
+      </View>
     </Modal>
-  )
-
+  );
 }

--- a/openwink-app/Components/index.ts
+++ b/openwink-app/Components/index.ts
@@ -8,3 +8,4 @@ export * from "./TooltipHeader";
 export * from "./SearchBarFilter";
 export * from "./CommandSequenceBottomSheet";
 export * from "./AboutFooter";
+export * from "./EditQuickLinksModal";

--- a/openwink-app/Pages/Home/CreateCustomCommands/MainView.tsx
+++ b/openwink-app/Pages/Home/CreateCustomCommands/MainView.tsx
@@ -72,7 +72,9 @@ export function MainView({ setModifyType, setEditCommandName }: IMainViewProps) 
             }
           </Pressable>
           <SearchBarFilter
+            useFilters
             searchFilterKey="name"
+            filterTitleText="Filter by Command Type"
             filters={FILTERS}
             filterFn={({ filterType, itemsToFilter, selectedFilters }) => {
               if (selectedFilters.length < 1) return itemsToFilter;

--- a/openwink-app/Pages/Home/CustomCommands.tsx
+++ b/openwink-app/Pages/Home/CustomCommands.tsx
@@ -67,6 +67,8 @@ export function CustomCommands() {
 
         <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "center", width: "90%", columnGap: 15, marginTop: 10, }}>
           <SearchBarFilter
+            useFilters
+            filterTitleText="Filter by Command Type"
             filterables={commands}
             searchFilterKey="name"
             filters={FILTERS}

--- a/openwink-app/Pages/Home/Home.tsx
+++ b/openwink-app/Pages/Home/Home.tsx
@@ -1,13 +1,15 @@
-import { useFocusEffect, useNavigation, useRoute, useTheme } from "@react-navigation/native";
+import { useFocusEffect, useNavigation, useNavigationState, useRoute, useTheme } from "@react-navigation/native";
 import { Pressable, SafeAreaView, ScrollView, StatusBar, Text, View, } from "react-native"
 import { ActivityIndicator } from "react-native";
 import { useColorTheme } from "../../hooks/useColorTheme";
 import IonIcons from "@expo/vector-icons/Ionicons";
+import Octicons from "@react-native-vector-icons/octicons";
 import { useBLE } from "../../hooks/useBLE";
 import { useCallback, useEffect, useState } from "react";
-import { AutoConnectStore } from "../../Storage";
-import { LongButton } from "../../Components";
+import { AutoConnectStore, QuickLinksStore } from "../../Storage";
+import { EditQuickLinksModal, LongButton, QuickLink } from "../../Components";
 import { MainHeader } from "../../Components";
+// import { EditQuickLinksModal, QuickLink } from "../../Components/EditQuickLinksModal";
 
 export function Home() {
 
@@ -20,8 +22,9 @@ export function Home() {
 
   const [fetchingModuleUpdateInfo, setFetchingModuleUpdateInfo] = useState(false);
   const [fetchingAppUpdateInfo, setFetchingAppUpdateInfo] = useState(false);
-  const [quickLinks, setQuickLinks] = useState([] as []);
 
+  const [quickLinksModalVisible, setQuickLinksModalVisible] = useState(false);
+  const [quickLinks, setQuickLinks] = useState(QuickLinksStore.getLinks());
 
   const {
     device,
@@ -45,6 +48,11 @@ export function Home() {
     updateProgress,
     updatingStatus
   } = useBLE();
+
+  const updateQuickLinks = (newQuickLinks: QuickLink[]) => {
+    QuickLinksStore.setLinks(newQuickLinks);
+    setQuickLinks(() => newQuickLinks);
+  }
 
   const checkAppUpdate = async () => {
     // fetch request to get app update info
@@ -149,43 +157,27 @@ export function Home() {
           />
         </View>
 
-
-        {/* QUICK LINKS */}
-        {/* <View style={theme.homeScreenButtonsContainer}>
-          <Text style={theme.labelHeader}>
-            Quick Links
-          </Text> */}
-        {/* CUSTOM WINK BUTTON */}
-        {/* <LongButton
-            //@ts-ignore
-            onPress={() => navigate.navigate("CustomWinkButton", { back: route.name, backHumanReadable: "Home" })}
-            key={"CustomWinkButton"}
-            icons={{ names: ["speedometer-outline", "chevron-forward-outline"], size: [20, 20] }}
-            text="Set Up Custom Wink Button"
-          /> */}
-        {/* COLOR THEME */}
-        {/* <LongButton
-            //@ts-ignore
-            onPress={() => navigate.navigate("Theme", { back: route.name })}
-            key={"Theme"}
-            icons={{ names: ["color-fill-outline", "chevron-forward-outline"], size: [20, 20] }}
-            text="Change App Theme"
-          />
-        </View> */}
-
-        {/* Includes: Icon, Navigation Name, Display Name */}
-
-        <View style={theme.homeScreenButtonsContainer}>
+        <View style={[theme.homeScreenButtonsContainer, { rowGap: 10, }]}>
           {/* QUICK LINKS HEADER */}
-          <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", width: "100%" }}>
+          <View style={{
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            width: "100%"
+          }}>
             <Text style={theme.labelHeader}>
               Quick Links
             </Text>
 
+            {/* EDIT Button */}
             <Pressable
-              style={{ flexDirection: "row", alignItems: "center", columnGap: 10 }}
-              // TODO: Open 
-              onPress={() => { }}
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                columnGap: 8
+              }}
+              hitSlop={10}
+              onPress={() => setQuickLinksModalVisible(true)}
             >
               {
                 ({ pressed }) =>
@@ -193,16 +185,32 @@ export function Home() {
                     <Text style={{
                       color: pressed ? colorTheme.buttonColor : colorTheme.headerTextColor,
                       fontSize: 15,
-                      fontFamily: "IBMPlexSans_400Regular",
+                      fontFamily: "IBMPlexSans_500Medium",
+
                     }}>
                       Edit
                     </Text>
-                    <IonIcons style={{ marginTop: 3 }} name="list" size={23} color={pressed ? colorTheme.buttonColor : colorTheme.headerTextColor} />
+                    <Octicons style={{ marginTop: 3 }} name="sliders" size={17} color={pressed ? colorTheme.buttonColor : colorTheme.headerTextColor} />
                   </>
               }
             </Pressable>
-
           </View>
+
+          {
+            quickLinks.length > 0 ?
+              quickLinks.map((link) => (
+                <LongButton
+                  key={link.title}
+                  //@ts-ignore
+                  onPress={() => navigate.navigate(link.navigation.page, { back: link.navigation.back, backHumanReadable: link.navigation.backHumanReadable })}
+                  icons={{ names: [link.icon, "chevron-forward-outline"], size: [20, 20] }}
+                  text={link.title}
+                />
+              ))
+              : <Text style={[theme.labelHeader, { alignSelf: "center", width: "100%", fontSize: 16 }]}>
+                No Quick Links Selected
+              </Text>
+          }
         </View>
 
 
@@ -278,6 +286,13 @@ export function Home() {
         </View>
 
       </ScrollView>
-    </View >
+
+      <EditQuickLinksModal
+        close={() => setQuickLinksModalVisible(false)}
+        visible={quickLinksModalVisible}
+        initialLinks={quickLinks}
+        onUpdateLinks={(updatedLinks) => updateQuickLinks(updatedLinks)}
+      />
+    </View>
   );
 }

--- a/openwink-app/Pages/Home/Home.tsx
+++ b/openwink-app/Pages/Home/Home.tsx
@@ -13,13 +13,15 @@ export function Home() {
 
   const navigate = useNavigation();
   const route = useRoute();
-  const { colorTheme, update, theme } = useColorTheme();
+  const { colorTheme, theme } = useColorTheme();
 
   const [moduleUpdateAvailable, setModuleUpdateAvailable] = useState(false as null | boolean);
   const [appUpdateAvailable, setAppUpdateAvailable] = useState(false as null | boolean);
 
   const [fetchingModuleUpdateInfo, setFetchingModuleUpdateInfo] = useState(false);
   const [fetchingAppUpdateInfo, setFetchingAppUpdateInfo] = useState(false);
+  const [quickLinks, setQuickLinks] = useState([] as []);
+
 
   const {
     device,
@@ -149,27 +151,61 @@ export function Home() {
 
 
         {/* QUICK LINKS */}
-        <View style={theme.homeScreenButtonsContainer}>
+        {/* <View style={theme.homeScreenButtonsContainer}>
           <Text style={theme.labelHeader}>
             Quick Links
-          </Text>
-          {/* CUSTOM WINK BUTTON */}
-          <LongButton
+          </Text> */}
+        {/* CUSTOM WINK BUTTON */}
+        {/* <LongButton
             //@ts-ignore
             onPress={() => navigate.navigate("CustomWinkButton", { back: route.name, backHumanReadable: "Home" })}
             key={"CustomWinkButton"}
             icons={{ names: ["speedometer-outline", "chevron-forward-outline"], size: [20, 20] }}
             text="Set Up Custom Wink Button"
-          />
-          {/* COLOR THEME */}
-          <LongButton
+          /> */}
+        {/* COLOR THEME */}
+        {/* <LongButton
             //@ts-ignore
             onPress={() => navigate.navigate("Theme", { back: route.name })}
             key={"Theme"}
             icons={{ names: ["color-fill-outline", "chevron-forward-outline"], size: [20, 20] }}
             text="Change App Theme"
           />
+        </View> */}
+
+        {/* Includes: Icon, Navigation Name, Display Name */}
+
+        <View style={theme.homeScreenButtonsContainer}>
+          {/* QUICK LINKS HEADER */}
+          <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", width: "100%" }}>
+            <Text style={theme.labelHeader}>
+              Quick Links
+            </Text>
+
+            <Pressable
+              style={{ flexDirection: "row", alignItems: "center", columnGap: 10 }}
+              // TODO: Open 
+              onPress={() => { }}
+            >
+              {
+                ({ pressed }) =>
+                  <>
+                    <Text style={{
+                      color: pressed ? colorTheme.buttonColor : colorTheme.headerTextColor,
+                      fontSize: 15,
+                      fontFamily: "IBMPlexSans_400Regular",
+                    }}>
+                      Edit
+                    </Text>
+                    <IonIcons style={{ marginTop: 3 }} name="list" size={23} color={pressed ? colorTheme.buttonColor : colorTheme.headerTextColor} />
+                  </>
+              }
+            </Pressable>
+
+          </View>
         </View>
+
+
 
 
         {/* Status about app/module Updates + if update is available -> press = update */}

--- a/openwink-app/Storage/QuickLinksStore.ts
+++ b/openwink-app/Storage/QuickLinksStore.ts
@@ -1,3 +1,44 @@
+import { QuickLink } from "../Components";
+import Storage from "./Storage";
+
+const QUICKLINKS_KEY = "quick-links";
+
+const DEFAULTS: QuickLink[] = [
+  {
+    icon: "speedometer-outline",
+    navigation: {
+      back: "Home",
+      backHumanReadable: "Home",
+      page: "CustomWinkButton"
+    },
+    title: "Set Up Custom Wink Button"
+  },
+  {
+    icon: "color-fill-outline",
+    navigation: {
+      back: "Home",
+      backHumanReadable: "Home",
+      page: "Theme"
+    },
+    title: "Change App Theme"
+  }
+]
 export abstract class QuickLinksStore {
+
+  static getLinks(): QuickLink[] {
+    const linksFromStorage = Storage.getString(QUICKLINKS_KEY);
+    if (!linksFromStorage) return DEFAULTS;
+
+    const parsed = JSON.parse(linksFromStorage);
+    return parsed as QuickLink[];
+  }
+
+  static setLinks(links: QuickLink[]) {
+    Storage.set(QUICKLINKS_KEY, JSON.stringify(links));
+  }
+
+  static reset() {
+    Storage.delete(QUICKLINKS_KEY);
+  }
 
 }

--- a/openwink-app/Storage/QuickLinksStore.ts
+++ b/openwink-app/Storage/QuickLinksStore.ts
@@ -1,0 +1,3 @@
+export abstract class QuickLinksStore {
+
+}

--- a/openwink-app/Storage/index.ts
+++ b/openwink-app/Storage/index.ts
@@ -6,3 +6,4 @@ export * from "./DeviceMACStore";
 export * from "./FirmwareStore";
 export * from "./SleepyEyeStore";
 export * from "./ThemeStore";
+export * from "./QuickLinksStore";

--- a/openwink-app/helper/Constants.ts
+++ b/openwink-app/helper/Constants.ts
@@ -106,7 +106,7 @@ export const SETTINGS_DATA: Array<{
       pageSymbol: "color-fill-outline"
     },
     {
-      pageName: "System Terms Of Use",
+      pageName: "System Terms of Use",
       navigationName: "TermsOfUse",
       pageSymbol: "document-text-outline",
     }

--- a/openwink-app/package-lock.json
+++ b/openwink-app/package-lock.json
@@ -13,6 +13,7 @@
         "@gorhom/portal": "^1.0.14",
         "@ptomasroos/react-native-multi-slider": "^2.2.2",
         "@react-native-vector-icons/material-design-icons": "^12.3.0",
+        "@react-native-vector-icons/octicons": "^20.3.0",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/native-stack": "^7.1.14",
@@ -3516,6 +3517,22 @@
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/@react-native-vector-icons/material-design-icons/-/material-design-icons-12.3.0.tgz",
       "integrity": "sha512-0fut9zjUJtGWwjGQ0lbirmPnjMkou9vkBY3d3ZsaHqXCBgV3fGeOWuRZ17eDpsGy/9BTRtBRI85RYdFGhdcB4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native-vector-icons/common": "^12.3.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@react-native-vector-icons/octicons": {
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/@react-native-vector-icons/octicons/-/octicons-20.3.0.tgz",
+      "integrity": "sha512-MTGbM7R/KjpVFuKfODPuIVmyCfNs7tRPJpKaIRQHo4RO6cflqCxZAfSZhtLE+AQ02bk0dN5r131hn6SnYRZyEw==",
       "license": "MIT",
       "dependencies": {
         "@react-native-vector-icons/common": "^12.3.0"

--- a/openwink-app/package.json
+++ b/openwink-app/package.json
@@ -14,6 +14,7 @@
     "@gorhom/portal": "^1.0.14",
     "@ptomasroos/react-native-multi-slider": "^2.2.2",
     "@react-native-vector-icons/material-design-icons": "^12.3.0",
+    "@react-native-vector-icons/octicons": "^20.3.0",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/native-stack": "^7.1.14",


### PR DESCRIPTION
See #19 

Allows user to customize their quick links section, allowing for up to 7 different pages to be visible.
Skips the hassle of needing to click through 3 to 4 different screens to get to a setting buried deep, especially if the setting is changed often (say, sleepy eyes). 