### PR TITLE
Improve styling for bottom buttons when using light backgrounds

### DIFF
--- a/openwink-app/Navigation.tsx
+++ b/openwink-app/Navigation.tsx
@@ -68,7 +68,7 @@ const CustomBottomTabs = ({ descriptors, insets, navigation, state }: BottomTabB
         };
 
 
-        let iconName: any;
+        let iconName: 'home' | 'home-outline' | 'help-circle' | 'help-circle-outline' | 'settings' | 'settings-outline' = 'home';
 
         if (route.name === "Home") iconName = isFocused ? 'home' : 'home-outline';
         else if (route.name === "Help") iconName = isFocused ? "help-circle" : "help-circle-outline" as const;
@@ -86,7 +86,7 @@ const CustomBottomTabs = ({ descriptors, insets, navigation, state }: BottomTabB
             onLongPress={onLongPress}
           >
             <View style={isFocused ? theme.bottomTabsPillActive : theme.bottomTabsPill}>
-              <Ionicons name={iconName} size={26} color={isFocused ? colorTheme.buttonColor : colorTheme.headerTextColor} />
+              <Ionicons name={iconName} size={26} color={isFocused ? colorTheme.buttonColor : colorTheme.bottomTabsTextColor} />
               {
                 isFocused ? (
                   <Text style={theme.bottomTabsPillFocusedText}>
@@ -159,6 +159,7 @@ export function AppNavigator() {
   useEffect(() => {
     return () => { disconnectFromModule() };
   }, []);
+
   return (
     <>
       <Stack.Navigator screenOptions={{
@@ -183,7 +184,6 @@ export function AppNavigator() {
         <Stack.Screen name="CustomWinkButton" component={CustomWinkButton} />
 
       </Stack.Navigator>
-
 
       <Toast config={toastConfig} />
     </>

--- a/openwink-app/Pages/Settings/AppTheme.tsx
+++ b/openwink-app/Pages/Settings/AppTheme.tsx
@@ -50,18 +50,17 @@ export function AppTheme() {
 
       <View style={theme.homeScreenButtonsContainer}>
         {
-          Object.keys(ColorTheme.themeNames).map((val, i) => (
+          ColorTheme.themeKeys.map((themeKey) =>
             <LongButton
-              key={val}
-              pressableStyle={val === currentTheme ? { backgroundColor: ColorTheme[val as keyof typeof ColorTheme.themeNames].buttonColor } : {}}
-              icons={{ names: [null, val === currentTheme ? "checkmark-circle" : "ellipse-outline"], size: [null, 22] }}
+              key={themeKey}
+              pressableStyle={themeKey === themeName ? { backgroundColor: ColorTheme[themeKey].buttonColor } : {}}
+              icons={{ names: [null, themeKey === themeName ? "checkmark-circle" : "ellipse-outline"], size: [null, 22] }}
               onPress={() => {
-                setCurrentTheme(val as keyof typeof ColorTheme.themeNames);
-                setTheme(val as keyof typeof ColorTheme.themeNames);
+                setTheme(themeKey);
               }}
-              text={ColorTheme.themeNames[val as keyof typeof ColorTheme.themeNames]}
+              text={ColorTheme.themeNames[themeKey]}
             />
-          ))
+          )
         }
 
       </View>

--- a/openwink-app/helper/Constants.ts
+++ b/openwink-app/helper/Constants.ts
@@ -188,26 +188,39 @@ export interface ThemeColors {
   disabledButtonTextColor: HexNumber;
   headerTextColor: HexNumber;
   bottomTabsBackground: HexNumber;
+  bottomTabsTextColor: HexNumber;
   bottomTabsPill: HexNumber;
   textColor: HexNumber;
 }
 
 export namespace ColorTheme {
 
-  export const themeNames = {
+  export const themeKeys = [
+    "crystalWhite",
+    "brilliantBlack",
+    "classicRed",
+    "sunburstYellow",
+    "marinerBlue",
+    "britishRacingGreen",
+  ] as const;
+
+  export type ThemeKey = typeof themeKeys[number];
+
+  export const themeNames: Record<ThemeKey, string> = {
     crystalWhite: "Crystal White",
     brilliantBlack: "Brilliant Black",
     classicRed: "Classic Red",
     sunburstYellow: "Sunburst Yellow",
     marinerBlue: "Mariner Blue",
     britishRacingGreen: "British Racing Green",
-  }
+  };
 
 
   export const crystalWhite: ThemeColors = {
     backgroundPrimaryColor: "#f1f1f1",
     backgroundSecondaryColor: "#ffffff",
     bottomTabsBackground: "#ffffff",
+    bottomTabsTextColor: "#141414",
     bottomTabsPill: "#f5ebdf",
     dropdownColor: "#e8e8e8",
     buttonColor: "#bd9664",
@@ -222,6 +235,7 @@ export namespace ColorTheme {
     backgroundPrimaryColor: "#141414",
     backgroundSecondaryColor: "#262629",
     bottomTabsBackground: "#1c1c1c",
+    bottomTabsTextColor: "#ffffff",
     bottomTabsPill: "#efe6e6",
     dropdownColor: "#2F2F32",
     buttonColor: "#550000", // Burgundy (default)
@@ -236,6 +250,7 @@ export namespace ColorTheme {
     backgroundPrimaryColor: "#141414",
     backgroundSecondaryColor: "#1e1e1e",
     bottomTabsBackground: "#ffffff",
+    bottomTabsTextColor: "#141414",
     bottomTabsPill: "#ffffff",
     dropdownColor: "#37373b",
     buttonColor: "#c8102e", // Classic Red
@@ -250,6 +265,7 @@ export namespace ColorTheme {
     backgroundPrimaryColor: "#141414",
     backgroundSecondaryColor: "#1e1e1e",
     bottomTabsBackground: "#ffffff",
+    bottomTabsTextColor: "#141414",
     bottomTabsPill: "#ffffff",
     dropdownColor: "#37373b",
     buttonColor: "#ffcc00", // Sunburst Yellow
@@ -264,6 +280,7 @@ export namespace ColorTheme {
     backgroundPrimaryColor: "#141414",
     backgroundSecondaryColor: "#1e1e1e",
     bottomTabsBackground: "#ffffff",
+    bottomTabsTextColor: "#141414",
     bottomTabsPill: "#ffffff",
     dropdownColor: "#37373b",
     buttonColor: "#0033a0", // Marina Blue
@@ -278,6 +295,7 @@ export namespace ColorTheme {
     backgroundPrimaryColor: "#141414",
     backgroundSecondaryColor: "#1e1e1e",
     bottomTabsBackground: "#ffffff",
+    bottomTabsTextColor: "#141414",
     bottomTabsPill: "#ffffff",
     dropdownColor: "#37373b",
     buttonColor: "#004d26", // British Racing Green


### PR DESCRIPTION
When selecting a theme with a light bottom tab color the unselected options were not visible. This PR adds a new `bottomTabsTextColor` to the themes.

Additionally added some type safety for theme keys and icon names.