### PR TITLE
Use SafeAreaView for improved layout handling

### DIFF
--- a/openwink-app/App.tsx
+++ b/openwink-app/App.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from './Providers/ThemeProvider';
 import { AppNavigator } from './Navigation';
 import { PortalProvider } from '@gorhom/portal';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 
 export default function App() {
@@ -20,16 +21,18 @@ export default function App() {
   if (!loaded) return null;
 
   return (
-    <NavigationContainer>
-      <BleProvider>
-        <ThemeProvider>
-          <GestureHandlerRootView>
-            <PortalProvider>
-              <AppNavigator />
-            </PortalProvider>
-          </GestureHandlerRootView>
-        </ThemeProvider>
-      </BleProvider>
-    </NavigationContainer>
+    <SafeAreaProvider>
+      <NavigationContainer>
+        <BleProvider>
+          <ThemeProvider>
+            <GestureHandlerRootView>
+              <PortalProvider>
+                <AppNavigator />
+              </PortalProvider>
+            </GestureHandlerRootView>
+          </ThemeProvider>
+        </BleProvider>
+      </NavigationContainer>
+    </SafeAreaProvider>
   );
 }

--- a/openwink-app/Pages/Home/CreateCustomCommands/MainView.tsx
+++ b/openwink-app/Pages/Home/CreateCustomCommands/MainView.tsx
@@ -8,6 +8,7 @@ import IonIcons from "@expo/vector-icons/Ionicons";
 import { HeaderWithBackButton, SearchBarFilter } from "../../../Components";
 import { useFocusEffect, useRoute } from "@react-navigation/native";
 import { ModifyType } from "./ModifyView";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 interface IMainViewProps {
   setModifyType: (type: ModifyType) => void;
@@ -35,7 +36,7 @@ export function MainView({ setModifyType, setEditCommandName }: IMainViewProps) 
   }, []));
 
   return (
-    <View style={theme.container}>
+    <SafeAreaView style={theme.container}>
 
       <HeaderWithBackButton
         backText={back}
@@ -140,7 +141,7 @@ export function MainView({ setModifyType, setEditCommandName }: IMainViewProps) 
           </ScrollView>
         </View>
       </View>
-    </View>
+    </SafeAreaView>
   )
 
 }

--- a/openwink-app/Pages/Home/CreateCustomCommands/ModifyView.tsx
+++ b/openwink-app/Pages/Home/CreateCustomCommands/ModifyView.tsx
@@ -1,5 +1,5 @@
 
-import { FlatList, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { FlatList, Pressable, SafeAreaView, Text, TextInput, View } from "react-native";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import IonIcons from "@expo/vector-icons/Ionicons";
@@ -10,7 +10,6 @@ import { useFocusEffect, useRoute } from "@react-navigation/native";
 import { CommandInput, CommandOutput, CustomCommandStore } from "../../../Storage";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ConfirmationModal } from "../../../Components/ConfirmationModal";
-import { useThrottle } from "../../../helper/Functions";
 import { ComponentModal } from "../../../Components/ComponentModal";
 import { DefaultCommandValue, DefaultCommandValueEnglish } from "../../../helper/Constants";
 
@@ -215,9 +214,9 @@ export function ModifyView({ type, commandName, onDiscard, onSave }: IModifyView
   }, [command.command?.length]);
 
   return (
-    <>
+    <SafeAreaView style={theme.container}>
       {/* MAIN Modify VIEW */}
-      <View style={theme.container}>
+      <View>
 
         <HeaderWithBackButton
           backText={back}
@@ -465,6 +464,6 @@ export function ModifyView({ type, commandName, onDiscard, onSave }: IModifyView
           }}
         />
       </View>
-    </>
+    </SafeAreaView>
   )
 }

--- a/openwink-app/Pages/Home/CustomCommands.tsx
+++ b/openwink-app/Pages/Home/CustomCommands.tsx
@@ -1,14 +1,15 @@
 import { Pressable, Text, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import { useColorTheme } from "../../hooks/useColorTheme";
-import { useFocusEffect, useNavigation, useRoute } from "@react-navigation/native";
+import { useFocusEffect, useRoute } from "@react-navigation/native";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useBLE } from "../../hooks/useBLE";
 import { CommandSequenceBottomSheet, HeaderWithBackButton, SearchBarFilter } from "../../Components";
-import { CommandInput, CommandOutput, CustomCommandStore } from "../../Storage";
+import { CommandOutput, CustomCommandStore } from "../../Storage";
 import { DefaultCommandValueEnglish } from "../../helper/Constants";
 import BottomSheet from "@gorhom/bottom-sheet";
 import IonIcons from "@expo/vector-icons/Ionicons";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 const FILTERS = ["Delay", ...DefaultCommandValueEnglish] as const;
 export function CustomCommands() {
@@ -54,7 +55,7 @@ export function CustomCommands() {
   const canRunCommands = device && !customCommandActive.current;
 
   return (
-    <View style={theme.container}>
+    <SafeAreaView style={theme.container}>
 
       <HeaderWithBackButton
         backText={back}
@@ -203,6 +204,6 @@ export function CustomCommands() {
         close={() => { setDisplayedCommand(null); }}
       />
 
-    </View>
+    </SafeAreaView>
   )
 }

--- a/openwink-app/Pages/Home/Home.tsx
+++ b/openwink-app/Pages/Home/Home.tsx
@@ -140,7 +140,7 @@ export function Home() {
 
   return (
     <>
-      <View style={theme.container}>
+      <SafeAreaView style={theme.tabContainer}>
         <MainHeader text="Home" />
 
         <ScrollView contentContainerStyle={theme.contentContainer} >
@@ -350,22 +350,22 @@ export function Home() {
 
         </ScrollView>
 
-      </View>
+        </SafeAreaView>
 
-      <EditQuickLinksModal
-        close={() => setQuickLinksModalVisible(false)}
-        visible={quickLinksModalVisible}
-        initialLinks={quickLinks}
-        onUpdateLinks={(updatedLinks) => updateQuickLinks(updatedLinks)}
-      />
-
-      <ModuleUpdateModal
-        onRequestClose={() => setInstallingFirmware(false)}
-        visible={installingFirmware}
-        binSizeBytes={updateSize}
-        version={updateVersion}
-        description={updateDescription}
-      />
-    </>
+        <EditQuickLinksModal
+          close={() => setQuickLinksModalVisible(false)}
+          visible={quickLinksModalVisible}
+          initialLinks={quickLinks}
+          onUpdateLinks={(updatedLinks) => updateQuickLinks(updatedLinks)}
+        />
+  
+        <ModuleUpdateModal
+          onRequestClose={() => setInstallingFirmware(false)}
+          visible={installingFirmware}
+          binSizeBytes={updateSize}
+          version={updateVersion}
+          description={updateDescription}
+        />
+      </>
   );
 }

--- a/openwink-app/Pages/Home/StandardCommands.tsx
+++ b/openwink-app/Pages/Home/StandardCommands.tsx
@@ -1,17 +1,13 @@
-import { Pressable, ScrollView, Text, View } from "react-native";
+import { Pressable, SafeAreaView, Text, View } from "react-native";
 import { useColorTheme } from "../../hooks/useColorTheme";
-import IonIcons from "@expo/vector-icons/Ionicons";
 import { useNavigation, useRoute } from "@react-navigation/native";
-import { useEffect, useState } from "react";
 import { useBLE } from "../../hooks/useBLE";
-import { ActivityIndicator } from "react-native";
 import { DEFAULT_COMMAND_DATA, DEFAULT_WINK_DATA } from "../../helper/Constants";
 import { HeaderWithBackButton } from "../../Components";
 
 export function StandardCommands() {
 
   const { colorTheme, theme } = useColorTheme();
-  const navigation = useNavigation();
   const route = useRoute();
   //@ts-ignore
   const { back } = route.params;
@@ -42,7 +38,7 @@ export function StandardCommands() {
     (rightStatus !== 0 && rightStatus !== 1);
 
   return (
-    <View style={theme.container}>
+    <SafeAreaView style={theme.container}>
 
       <HeaderWithBackButton
         backText={back}
@@ -230,6 +226,6 @@ export function StandardCommands() {
           </View>
         </View>
       </View>
-    </View>
+    </SafeAreaView>
   )
 }

--- a/openwink-app/Pages/HowToUse.tsx
+++ b/openwink-app/Pages/HowToUse.tsx
@@ -1,5 +1,4 @@
-import { useTheme } from "@react-navigation/native";
-import { SafeAreaView, Text, View } from "react-native"
+import { SafeAreaView } from "react-native"
 import { useColorTheme } from "../hooks/useColorTheme";
 import { MainHeader } from "../Components";
 
@@ -8,8 +7,8 @@ export function HowToUse() {
   const { theme } = useColorTheme();
 
   return (
-    <View style={theme.container}>
+    <SafeAreaView style={theme.tabContainer}>
       <MainHeader text="Help" />
-    </View>
+    </SafeAreaView>
   );
 }

--- a/openwink-app/Pages/Settings/AppTheme.tsx
+++ b/openwink-app/Pages/Settings/AppTheme.tsx
@@ -1,11 +1,11 @@
 import { Pressable, Text, View } from "react-native";
 import { useColorTheme } from "../../hooks/useColorTheme";
 import IonIcons from "@expo/vector-icons/Ionicons";
-import { useFocusEffect, useNavigation, useNavigationState, useRoute } from "@react-navigation/native";
-import { useEffect, useState } from "react";
+import { useRoute } from "@react-navigation/native";
 import { ColorTheme } from "../../helper/Constants";
 import { LongButton } from "../../Components/LongButton";
 import { HeaderWithBackButton } from "../../Components";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 export function AppTheme() {
   const {
@@ -13,22 +13,15 @@ export function AppTheme() {
     themeName,
     theme,
     setTheme,
-    update,
     reset,
   } = useColorTheme();
 
-  const navigation = useNavigation();
   const route = useRoute();
   //@ts-ignore
   const { back } = route.params;
-  const [currentTheme, setCurrentTheme] = useState("brilliantBlack" as keyof typeof ColorTheme.themeNames);
-
-  useFocusEffect(() => {
-    setCurrentTheme(themeName);
-  });
 
   return (
-    <View style={theme.container}>
+    <SafeAreaView style={theme.container}>
       <HeaderWithBackButton
         backText={back}
         headerText="App Theme"
@@ -77,6 +70,6 @@ export function AppTheme() {
           Reset theme
         </Text>
       </Pressable>
-    </View>
+    </SafeAreaView>
   )
 }

--- a/openwink-app/Pages/Settings/Information.tsx
+++ b/openwink-app/Pages/Settings/Information.tsx
@@ -1,16 +1,17 @@
-import { Linking, Pressable, ScrollView, Text, View } from "react-native";
+import { Pressable, ScrollView, Text, View } from "react-native";
 import { useColorTheme } from "../../hooks/useColorTheme";
 import { useFocusEffect, useNavigation, useRoute } from "@react-navigation/native";
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import IonIcons from "@expo/vector-icons/Ionicons";
 import { useBLE } from "../../hooks/useBLE";
 import { ColorTheme, countToEnglish, DefaultCommandValueEnglish, buttonBehaviorMap } from "../../helper/Constants";
 import { CommandOutput, CustomCommandStore, CustomOEMButtonStore } from "../../Storage";
 import { ButtonBehaviors, Presses } from "../../helper/Types";
 import * as Application from "expo-application";
-import { CommandSequenceBottomSheet } from "../../Components";
+import { CommandSequenceBottomSheet, HeaderWithBackButton } from "../../Components";
 import BottomSheet from "@gorhom/bottom-sheet";
 import { getDeviceUUID } from "../../helper/Functions";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 export function Information() {
 
@@ -90,33 +91,12 @@ export function Information() {
   const { back } = route.params;
 
   return (
-    <View style={theme.container}>
-
-      <View style={theme.headerContainer}>
-        <Pressable
-          style={theme.backButtonContainer}
-          onPress={() => navigation.goBack()}
-        >
-          {
-            ({ pressed }) => (
-              <>
-                <IonIcons style={theme.backButtonContainerIcon} name="chevron-back-outline" color={pressed ? colorTheme.buttonColor : colorTheme.headerTextColor} size={23} />
-
-                <Text style={pressed ? theme.backButtonContainerTextPressed : theme.backButtonContainerText}>
-                  {back}
-                </Text>
-              </>
-            )
-          }
-        </Pressable>
-
-
-        <Text style={theme.subSettingHeaderText}>
-          System Info
-        </Text>
-
-      </View>
-
+    <SafeAreaView style={theme.container}>
+        <HeaderWithBackButton
+          backText={back}
+          headerText="System Info"
+          headerTextStyle={theme.settingsHeaderText}
+        />
 
       <ScrollView contentContainerStyle={theme.infoContainer}>
 
@@ -275,6 +255,6 @@ export function Information() {
         command={displayedCommand!}
       />
 
-    </View >
+    </SafeAreaView>
   )
 }

--- a/openwink-app/Pages/Settings/ModuleSettings/CustomWinkButton.tsx
+++ b/openwink-app/Pages/Settings/ModuleSettings/CustomWinkButton.tsx
@@ -1,4 +1,4 @@
-import { ActivityIndicator, Dimensions, Modal, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { ActivityIndicator, Dimensions, Modal, Pressable, SafeAreaView, ScrollView, Text, TextInput, View } from "react-native";
 import { useColorTheme } from "../../../hooks/useColorTheme";
 import IonIcons from "@expo/vector-icons/Ionicons";
 import { useFocusEffect, useNavigation, useRoute } from "@react-navigation/native";
@@ -101,7 +101,7 @@ export function CustomWinkButton() {
 
   return (
     <>
-      <View style={theme.container}>
+      <SafeAreaView style={theme.container}>
         <HeaderWithBackButton
           backText={backHumanReadable}
           headerText="Button"
@@ -313,7 +313,7 @@ export function CustomWinkButton() {
             </ScrollView>
           </View>
         </View>
-      </View >
+      </SafeAreaView>
 
 
       <CustomButtonActionModal

--- a/openwink-app/Pages/Settings/ModuleSettings/ModuleSettings.tsx
+++ b/openwink-app/Pages/Settings/ModuleSettings/ModuleSettings.tsx
@@ -11,6 +11,7 @@ import { HeaderWithBackButton } from "../../../Components";
 
 import Toast from "react-native-toast-message";
 import Storage from "../../../Storage/Storage";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 
 const moduleSettingsData: Array<{
@@ -127,7 +128,7 @@ export function ModuleSettings() {
 
   return (
     <>
-      <View style={theme.moduleSettingsContainer}>
+      <SafeAreaView style={theme.moduleSettingsContainer}>
         <HeaderWithBackButton
           backText={back}
           headerText="Module"
@@ -223,7 +224,7 @@ export function ModuleSettings() {
           }
 
         </View>
-      </View>
+      </SafeAreaView>
 
 
       <ConfirmationModal

--- a/openwink-app/Pages/Settings/ModuleSettings/SleepyEyeSettings.tsx
+++ b/openwink-app/Pages/Settings/ModuleSettings/SleepyEyeSettings.tsx
@@ -7,6 +7,7 @@ import { useBLE } from "../../../hooks/useBLE";
 import VerticalSlider from "rn-vertical-slider-matyno";
 import { HeaderWithBackButton } from "../../../Components";
 import { TooltipHeader } from "../../../Components";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 export function SleepyEyeSettings() {
 
@@ -34,7 +35,7 @@ export function SleepyEyeSettings() {
     (!device || ((leftStatus !== 1 && leftStatus !== 0) || (rightStatus !== 1 && rightStatus !== 0)));
 
   return (
-    <View style={theme.container}>
+    <SafeAreaView style={theme.container}>
       <HeaderWithBackButton
         backText={backHumanReadable}
         headerText="Sleepy"
@@ -181,7 +182,7 @@ export function SleepyEyeSettings() {
 
       </View>
 
-    </View>
+    </SafeAreaView>
   )
 
 }

--- a/openwink-app/Pages/Settings/ModuleSettings/WaveDelaySettings.tsx
+++ b/openwink-app/Pages/Settings/ModuleSettings/WaveDelaySettings.tsx
@@ -8,6 +8,7 @@ import RangeSlider from "react-native-sticky-range-slider";
 import Tooltip from "react-native-walkthrough-tooltip";
 import { HeaderWithBackButton } from "../../../Components/HeaderWithBackButton";
 import { TooltipHeader } from "../../../Components";
+import { SafeAreaView } from "react-native-safe-area-context";
 const MIN = 0;
 const MAX = 100;
 
@@ -42,7 +43,7 @@ export function WaveDelaySettings() {
   }, [waveDelayMulti])
 
   return (
-    <View style={theme.container}>
+    <SafeAreaView style={theme.container}>
       <HeaderWithBackButton
         backText={backHumanReadable}
         headerText="Waves"
@@ -148,7 +149,7 @@ export function WaveDelaySettings() {
           ))
         }
       </View>
-    </View>
+    </SafeAreaView>
   )
 
 }

--- a/openwink-app/Pages/Settings/Settings.tsx
+++ b/openwink-app/Pages/Settings/Settings.tsx
@@ -1,5 +1,5 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
-import { View } from "react-native"
+import { SafeAreaView, View } from "react-native"
 import { useColorTheme } from "../../hooks/useColorTheme";
 import { AboutFooter, LongButton } from "../../Components";
 import { MainHeader } from "../../Components";
@@ -7,14 +7,13 @@ import { SETTINGS_DATA } from "../../helper/Constants";
 
 export function Settings() {
 
-  const { colorTheme, theme } = useColorTheme();
+  const { theme } = useColorTheme();
 
   const navigate = useNavigation();
   const route = useRoute();
 
   return (
-    <>
-      <View style={theme.container}>
+      <SafeAreaView style={theme.tabContainer}>
         <MainHeader text="Settings" />
 
         <View style={theme.homeScreenButtonsContainer}>
@@ -39,7 +38,6 @@ export function Settings() {
 
         <AboutFooter />
 
-      </View >
-    </>
+      </SafeAreaView>
   );
 }

--- a/openwink-app/Pages/Settings/TermsOfUse.tsx
+++ b/openwink-app/Pages/Settings/TermsOfUse.tsx
@@ -1,21 +1,19 @@
-import { Pressable, ScrollView, Text, View } from "react-native";
+import { ScrollView } from "react-native";
 import { useColorTheme } from "../../hooks/useColorTheme";
 import { useNavigation, useRoute } from "@react-navigation/native";
-import { useState } from "react";
-import IonIcons from "@expo/vector-icons/Ionicons";
 import { HeaderWithBackButton } from "../../Components";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 export function TermsOfUse() {
 
-  const { colorTheme, theme } = useColorTheme();
+  const { theme } = useColorTheme();
 
-  const navigation = useNavigation();
   const route = useRoute();
   //@ts-ignore
   const { back } = route.params;
 
   return (
-    <View style={theme.container}>
+    <SafeAreaView style={theme.container}>
       <HeaderWithBackButton
         backText={back}
         headerText="Terms of Use"
@@ -25,6 +23,6 @@ export function TermsOfUse() {
 
       </ScrollView>
 
-    </View>
+    </SafeAreaView>
   )
 }

--- a/openwink-app/Providers/ThemeProvider.tsx
+++ b/openwink-app/Providers/ThemeProvider.tsx
@@ -8,6 +8,7 @@ import { StyleSheet, Text, TextStyle, View, ViewStyle } from "react-native";
 // TODO
 
 interface StyleSheetInterface extends StyleSheet.NamedStyles<any> {
+  tabContainer: ViewStyle;
   container: ViewStyle;
   infoContainer: ViewStyle;
   infoBoxOuter: ViewStyle;
@@ -151,6 +152,16 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
     setTheme_(
       StyleSheet.create<StyleSheetInterface>({
+        tabContainer: {
+          backgroundColor: themeColors.backgroundPrimaryColor,
+          height: "100%",
+          padding: 15,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          rowGap: 18,
+          margin: 10,
+        },
         container: {
           backgroundColor: themeColors.backgroundPrimaryColor,
           height: "100%",


### PR DESCRIPTION
When running the app on iOS the header was overlapping with some notch layouts. This PR uses a SafeAreaProvider and the SafeAreaView to automatically adjust for different notch layouts.

Additionally added the tabContainer style to give some margin to the main tab views. (The navigation stack already gives some margin to the internal views).