### PR TITLE
Fix: Mock Ble Custom Commands

### DIFF
--- a/openwink-app/Mock/MockBleSystem.ts
+++ b/openwink-app/Mock/MockBleSystem.ts
@@ -7,7 +7,7 @@ import {
   SOFTWARE_UPDATING_CHAR_UUID,
   SOFTWARE_STATUS_CHAR_UUID,
   HEADLIGHT_MOTION_IN_UUID,
-  CUSTOM_COMMAND_STATUS_UUID,
+  CUSTOM_COMMAND_UUID,
   CLIENT_MAC_UUID,
   WINK_SERVICE_UUID,
   OTA_SERVICE_UUID,
@@ -63,7 +63,7 @@ class MockCharacteristicStore {
       this.values.set(SOFTWARE_UPDATING_CHAR_UUID, '0');
       this.values.set(SOFTWARE_STATUS_CHAR_UUID, 'idle');
       this.values.set(HEADLIGHT_MOTION_IN_UUID, '750');
-      this.values.set(CUSTOM_COMMAND_STATUS_UUID, '0');
+      this.values.set(CUSTOM_COMMAND_UUID, '0');
       this.values.set(CLIENT_MAC_UUID, '0');
       this.values.set(FIRMWARE_UUID, '0.3.5');
     }
@@ -173,6 +173,7 @@ export class MockDevice implements Partial<Device> {
   private connected: boolean = true;
   private disconnectCallback: ((error: any, device: Device) => void) | null = null;
   private animationQueue: Promise<void> = Promise.resolve();
+  private customCommandInterrupted: boolean = false;
   serviceUUIDs?: string[];
 
   constructor(id: string = 'MOCK-MODULE-001', name: string = 'Open Wink Mock') {
@@ -280,9 +281,8 @@ export class MockDevice implements Partial<Device> {
         mockStore.setValue(CLIENT_MAC_UUID, '1');
         break;
 
-      case CUSTOM_COMMAND_STATUS_UUID:
-        mockStore.setValue(BUSY_CHAR_UUID, value);
-        mockStore.setValue(CUSTOM_COMMAND_STATUS_UUID, value);
+      case CUSTOM_COMMAND_UUID:
+        await this.handleCustomCommand(value);
         break;
 
       case CUSTOM_BUTTON_UPDATE_UUID:
@@ -325,7 +325,7 @@ export class MockDevice implements Partial<Device> {
 
   private async handleHeadlightCommand(command: DefaultCommandValue): Promise<void> {
     this.animationQueue = this.animationQueue.then(async () => {
-      const customCommandActive = mockStore.getValue(CUSTOM_COMMAND_STATUS_UUID) === '1';
+      const customCommandActive = mockStore.getValue(CUSTOM_COMMAND_UUID) === '1';
 
       if (!customCommandActive) {
         mockStore.setValue(BUSY_CHAR_UUID, '1');
@@ -396,6 +396,127 @@ export class MockDevice implements Partial<Device> {
     });
     
     await this.animationQueue;
+  }
+
+  private async handleCustomCommand(value: string): Promise<void> {
+    // New flow: first write is '1' to enable, second write is the command sequence
+    if (value === '1') {
+      // Enable custom command mode
+      console.log('Mock: Custom command mode enabled');
+      this.customCommandInterrupted = false;
+      mockStore.setValue(CUSTOM_COMMAND_UUID, '1');
+      mockStore.setValue(BUSY_CHAR_UUID, '1');
+      return;
+    }
+
+    if (value === '0') {
+      // Disable custom command mode (interrupt)
+      console.log('Mock: Custom command interrupted');
+      this.customCommandInterrupted = true;
+      return;
+    }
+
+    // Parse and execute command sequence
+    // Format: "4-d500-5-d500-4" where numbers are commands and d### are delays
+    console.log(`Mock: Executing custom command sequence: ${value}`);
+
+    this.animationQueue = this.animationQueue.then(async () => {
+      try {
+        const parts = value.split('-');
+        const headlightMotionDuration = parseInt(mockStore.getValue(HEADLIGHT_MOTION_IN_UUID));
+
+        for (const part of parts) {
+          // Check if interrupted before each step
+          if (this.customCommandInterrupted) {
+            console.log('Mock: Custom command execution interrupted');
+            break;
+          }
+
+          if (part.startsWith('d')) {
+            // Delay command
+            const delayMs = parseInt(part.substring(1));
+            console.log(`Mock: Delaying ${delayMs}ms`);
+            await this.simulateDelay(delayMs);
+          } else {
+            // Headlight command
+            const command = parseInt(part);
+            if (!isNaN(command)) {
+              console.log(`Mock: Executing command ${command}`);
+              await this.executeHeadlightCommand(command, headlightMotionDuration);
+            }
+          }
+        }
+      } catch (error) {
+        console.error('Error executing custom command sequence:', error);
+      } finally {
+        if (!this.customCommandInterrupted) {
+          console.log('Mock: Custom command sequence complete');
+        } else {
+          console.log('Mock: Custom command sequence terminated by interrupt');
+        }
+        mockStore.setValue(BUSY_CHAR_UUID, '0');
+        mockStore.setValue(CUSTOM_COMMAND_UUID, '0');
+        this.customCommandInterrupted = false;
+      }
+    });
+
+    await this.animationQueue;
+  }
+
+  private async executeHeadlightCommand(command: DefaultCommandValue, motionTime: number): Promise<void> {
+    // Execute individual headlight command without setting busy flag
+    // (busy is already managed by custom command handler)
+    switch (command) {
+      case DefaultCommandValue.LEFT_UP:
+        await this.animateStatus(LEFT_STATUS_UUID, ButtonStatus.UP, motionTime);
+        break;
+
+      case DefaultCommandValue.LEFT_DOWN:
+        await this.animateStatus(LEFT_STATUS_UUID, ButtonStatus.DOWN, motionTime);
+        break;
+
+      case DefaultCommandValue.RIGHT_UP:
+        await this.animateStatus(RIGHT_STATUS_UUID, ButtonStatus.UP, motionTime);
+        break;
+
+      case DefaultCommandValue.RIGHT_DOWN:
+        await this.animateStatus(RIGHT_STATUS_UUID, ButtonStatus.DOWN, motionTime);
+        break;
+
+      case DefaultCommandValue.BOTH_UP:
+        await Promise.all([
+          this.animateStatus(LEFT_STATUS_UUID, ButtonStatus.UP, motionTime),
+          this.animateStatus(RIGHT_STATUS_UUID, ButtonStatus.UP, motionTime),
+        ]);
+        break;
+
+      case DefaultCommandValue.BOTH_DOWN:
+        await Promise.all([
+          this.animateStatus(LEFT_STATUS_UUID, ButtonStatus.DOWN, motionTime),
+          this.animateStatus(RIGHT_STATUS_UUID, ButtonStatus.DOWN, motionTime),
+        ]);
+        break;
+
+      case DefaultCommandValue.LEFT_WINK:
+        await this.animateWink(LEFT_STATUS_UUID, motionTime);
+        break;
+
+      case DefaultCommandValue.RIGHT_WINK:
+        await this.animateWink(RIGHT_STATUS_UUID, motionTime);
+        break;
+
+      case DefaultCommandValue.BOTH_BLINK:
+        await this.animateBlink(motionTime);
+        break;
+
+      case DefaultCommandValue.LEFT_WAVE:
+        await this.animateWave('left', motionTime);
+        break;
+
+      case DefaultCommandValue.RIGHT_WAVE:
+        await this.animateWave('right', motionTime);
+        break;
+    }
   }
 
   private buttonStatusToPercentage(status: ButtonStatus): number {

--- a/openwink-app/Pages/Settings/DeveloperSettings.tsx
+++ b/openwink-app/Pages/Settings/DeveloperSettings.tsx
@@ -1,4 +1,4 @@
-import { Alert, Pressable, Switch, Text, View } from "react-native";
+import { Alert, Pressable, ScrollView, Switch, Text, View } from "react-native";
 import { useRoute } from "@react-navigation/native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useEffect, useMemo, useState } from "react";
@@ -68,119 +68,118 @@ export function DeveloperSettings() {
         headerTextStyle={theme.settingsHeaderText}
       />
 
-      {/* Disclaimer */}
-      <View style={theme.contentContainer}>
-        <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
-          <IonIcons name="warning-outline" size={20} color={colorTheme.buttonColor} style={{ marginRight: 8 }} />
-          <Text style={[theme.subSettingHeaderText, { color: colorTheme.buttonColor }]}>
-            Development Only
+      <ScrollView>
+        {/* Disclaimer */}
+        <View style={theme.contentContainer}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
+            <IonIcons name="warning-outline" size={20} color={colorTheme.buttonColor} style={{ marginRight: 8 }} />
+            <Text style={[theme.subSettingHeaderText, { color: colorTheme.buttonColor }]}>
+              Development Only
+            </Text>
+          </View>
+          <Text style={theme.text}>
+            These settings are only available in development mode and will not appear in production builds.
           </Text>
         </View>
-        <Text style={theme.text}>
-          These settings are only available in development mode and will not appear in production builds.
-        </Text>
-      </View>
 
-      {/* Device Info */}
-      <InfoBox title="Developer Info" data={devInfo} />
+        {/* Device Info */}
+        <InfoBox title="Developer Info" data={devInfo} />
 
-      {/* Mock BLE Settings */}
-      <View style={theme.contentContainer}>
-        <TooltipHeader
-          tooltipTitle="Mock BLE Manager"
-          tooltipContent={
-            <Text style={theme.tooltipContainerText}>
-              Use a simulated Bluetooth Low Energy manager instead of the real one. This allows testing the app without a physical device. The mock BLE system maintains state between app restarts, including headlight positions and custom button configurations.
+        {/* Mock BLE Settings */}
+        <View style={theme.contentContainer}>
+          <TooltipHeader
+            tooltipTitle="Mock BLE Manager"
+            tooltipContent={
+              <Text style={theme.tooltipContainerText}>
+                Use a simulated Bluetooth Low Energy manager instead of the real one. This allows testing the app without a physical device. The mock BLE system maintains state between app restarts, including headlight positions and custom button configurations.
+              </Text>
+            }
+          />
+          
+          {isSimulator && (
+            <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 12, padding: 12, backgroundColor: colorTheme.backgroundSecondaryColor, borderRadius: 8 }}>
+              <IonIcons name="information-circle" size={18} color={colorTheme.textColor} style={{ marginRight: 8 }} />
+              <Text style={[theme.text, { flex: 1, fontSize: 13 }]}>
+                Mock BLE is always enabled in simulator
+              </Text>
+            </View>
+          )}
+
+          <View style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginTop: 16,
+            padding: 16,
+            backgroundColor: colorTheme.backgroundSecondaryColor,
+            borderRadius: 12,
+          }}>
+            <View style={{ flex: 1, marginRight: 16 }}>
+              <Text style={[theme.settingsHeaderText, { fontSize: 16 }]}>
+                Enable Mock BLE
+              </Text>
+            </View>
+            <Switch
+              value={mockBleEnabled}
+              onValueChange={handleToggleMockBle}
+              trackColor={{ false: colorTheme.disabledButtonColor, true: colorTheme.buttonColor }}
+              thumbColor={colorTheme.backgroundPrimaryColor}
+              disabled={isSimulator}
+            />
+          </View>
+        </View>
+
+        {/* Mock BLE State Reset */}
+        {(mockBleEnabled || isSimulator) && (
+          <View style={theme.contentContainer}>
+            <Text style={theme.subSettingHeaderText}>
+              Mock BLE State
             </Text>
-          }
-        />
-        
-        {isSimulator && (
-          <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 12, padding: 12, backgroundColor: colorTheme.backgroundSecondaryColor, borderRadius: 8 }}>
-            <IonIcons name="information-circle" size={18} color={colorTheme.textColor} style={{ marginRight: 8 }} />
-            <Text style={[theme.text, { flex: 1, fontSize: 13 }]}>
-              Mock BLE is always enabled in simulator
-            </Text>
+            
+            <Pressable
+              style={({ pressed }) => [
+                {
+                  marginTop: 16,
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: 14,
+                  backgroundColor: pressed ? colorTheme.disabledButtonColor : colorTheme.backgroundSecondaryColor,
+                  borderRadius: 12,
+                  borderWidth: 1,
+                  borderColor: colorTheme.buttonColor,
+                }
+              ]}
+              onPress={() => {
+                Alert.alert(
+                  "Reset Mock BLE State",
+                  "This will clear all saved mock BLE data and restart the app with default values. Continue?",
+                  [
+                    { text: "Cancel", style: "cancel" },
+                    {
+                      text: "Reset",
+                      style: "destructive",
+                      onPress: () => {
+                        MockBleStore.clearState();
+                        Alert.alert(
+                          "State Cleared",
+                          "Mock BLE state has been reset. Please restart the app to apply changes.",
+                          [{ text: "OK" }]
+                        );
+                      }
+                    }
+                  ]
+                );
+              }}
+            >
+              <IonIcons name="refresh-outline" color={colorTheme.buttonColor} size={20} style={{ marginRight: 8 }} />
+              <Text style={[theme.settingsHeaderText, { color: colorTheme.buttonColor, fontSize: 15 }]}>
+                Reset Mock State
+              </Text>
+            </Pressable>
           </View>
         )}
-
-        <View style={{
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          marginTop: 16,
-          padding: 16,
-          backgroundColor: colorTheme.backgroundSecondaryColor,
-          borderRadius: 12,
-        }}>
-          <View style={{ flex: 1, marginRight: 16 }}>
-            <Text style={[theme.settingsHeaderText, { fontSize: 16 }]}>
-              Enable Mock BLE
-            </Text>
-          </View>
-          <Switch
-            value={mockBleEnabled}
-            onValueChange={handleToggleMockBle}
-            trackColor={{ false: colorTheme.disabledButtonColor, true: colorTheme.buttonColor }}
-            thumbColor={colorTheme.backgroundPrimaryColor}
-            disabled={isSimulator}
-          />
-        </View>
-      </View>
-
-      {/* Mock BLE State Reset */}
-      {mockBleEnabled && (
-        <View style={theme.contentContainer}>
-          <Text style={theme.subSettingHeaderText}>
-            Mock BLE State
-          </Text>
-          <Text style={theme.text}>
-            Reset the mock BLE system state to defaults. This will clear all saved characteristic values and custom button configurations.
-          </Text>
-          
-          <Pressable
-            style={({ pressed }) => [
-              {
-                marginTop: 16,
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'center',
-                padding: 14,
-                backgroundColor: pressed ? colorTheme.disabledButtonColor : colorTheme.backgroundSecondaryColor,
-                borderRadius: 12,
-                borderWidth: 1,
-                borderColor: colorTheme.buttonColor,
-              }
-            ]}
-            onPress={() => {
-              Alert.alert(
-                "Reset Mock BLE State",
-                "This will clear all saved mock BLE data and restart the app with default values. Continue?",
-                [
-                  { text: "Cancel", style: "cancel" },
-                  {
-                    text: "Reset",
-                    style: "destructive",
-                    onPress: () => {
-                      MockBleStore.clearState();
-                      Alert.alert(
-                        "State Cleared",
-                        "Mock BLE state has been reset. Please restart the app to apply changes.",
-                        [{ text: "OK" }]
-                      );
-                    }
-                  }
-                ]
-              );
-            }}
-          >
-            <IonIcons name="refresh-outline" color={colorTheme.buttonColor} size={20} style={{ marginRight: 8 }} />
-            <Text style={[theme.settingsHeaderText, { color: colorTheme.buttonColor, fontSize: 15 }]}>
-              Reset Mock State
-            </Text>
-          </Pressable>
-        </View>
-      )}
+      </ScrollView>
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
Handle the new Custom Command flow with the mock
This pull request updates the mock BLE system and developer settings page to support a new custom command flow and improve UI usability. The most significant changes are the refactoring of custom command handling in the mock BLE system and the addition of a scrollable view in the developer settings page.

### Mock BLE System: Custom Command Refactor

* Replaced all references to `CUSTOM_COMMAND_STATUS_UUID` with `CUSTOM_COMMAND_UUID` throughout `MockBleSystem.ts` for consistency and clarity. [[1]](diffhunk://#diff-992aa565bd6967ede0843be1a8320b0c07635f4083fd1b308ff45408d66dc433L10-R10) [[2]](diffhunk://#diff-992aa565bd6967ede0843be1a8320b0c07635f4083fd1b308ff45408d66dc433L66-R66) [[3]](diffhunk://#diff-992aa565bd6967ede0843be1a8320b0c07635f4083fd1b308ff45408d66dc433L283-R285) [[4]](diffhunk://#diff-992aa565bd6967ede0843be1a8320b0c07635f4083fd1b308ff45408d66dc433L328-R328)
* Introduced a new `handleCustomCommand` method in `MockDevice` to support a two-step custom command flow: enabling/disabling custom command mode and parsing/executing command sequences with support for delays and interruption.
* Added `customCommandInterrupted` state to allow interruption of custom command execution.

### Developer Settings Page: Usability Improvements

* Wrapped the developer settings content in a `ScrollView` to improve accessibility for long content. [[1]](diffhunk://#diff-d08f7dbfc641465738ecc888b3177a686a2612753944fe963ad86622c75b9aebL1-R1) [[2]](diffhunk://#diff-d08f7dbfc641465738ecc888b3177a686a2612753944fe963ad86622c75b9aebR71) [[3]](diffhunk://#diff-d08f7dbfc641465738ecc888b3177a686a2612753944fe963ad86622c75b9aebR182)
* Updated the condition for displaying the mock BLE state reset option to show for both mock BLE and simulator environments.