### PR TITLE
Feature: Bluetooth Low Energy OTA Updates

### DIFF
--- a/openwink-app/helper/Handlers/OTA.ts
+++ b/openwink-app/helper/Handlers/OTA.ts
@@ -38,39 +38,20 @@ export abstract class OTA {
       const json = await response.json();
       const version = json["version"] as FirmwareType;
       const description = json["description"] as string;
+      const size = json["size"] as number;
       this.updateDescription = description;
       this.setLatestVersion(version);
       this.setActiveVersion();
-
-      if (this.shouldUpdate()) {
-        const firmwareResponse = await fetch(`${UPDATE_URL}/firmware`,
-          {
-            method: "GET",
-            headers: {
-              authorization: DeviceMACStore.getStoredMAC() ?? "",
-            }
-          }
-        );
-
-        if (!firmwareResponse.ok) {
-          throw new Error(`Failed to fetch firmware size: ${firmwareResponse.status} ${firmwareResponse.statusText}`);
-        }
-
-        const firmwareBlob = await firmwareResponse.blob();
-        const blobWithType = firmwareBlob.slice(0, firmwareBlob.size, "application/octet-stream");
-
-        this.updateSizeBytes = blobWithType.size;
-
-      }
+      this.updateSizeBytes = size;
 
       return this.shouldUpdate();
     } catch (error) {
       clearTimeout(timeoutId);
-      
+
       if (error instanceof Error && error.name === 'AbortError') {
         throw new Error('Update check timed out. Please check your internet connection and try again.');
       }
-      
+
       throw error;
     }
   }

--- a/update-server/functions/api.ts
+++ b/update-server/functions/api.ts
@@ -35,10 +35,15 @@ const auth = async (req: Request, res: Response, next: NextFunction) => {
 
 router.get("/", auth, async (req, res) => {
   const pathToUpdateJson = path.join(__dirname, "../files/update.json");
-
+  const pathToUpdateBin = path.join(__dirname, "../files/update.bin");
   if (fs.existsSync(pathToUpdateJson)) {
     const file = fs.readFileSync(pathToUpdateJson, "ascii");
-    const data = JSON.parse(file);
+    const tempBin = fs.readFileSync(pathToUpdateBin, "binary");
+
+    const data = {
+      size: tempBin.length,
+      ...JSON.parse(file)
+    };
 
     res.status(200).json(data);
   } else
@@ -47,7 +52,6 @@ router.get("/", auth, async (req, res) => {
 
 router.get("/firmware", auth, async (req, res) => {
   const pathToUpdateBin = path.join(__dirname, "../files/update.bin");
-  console.log(pathToUpdateBin);
   if (fs.existsSync(pathToUpdateBin)) {
     res.status(200).contentType("application/octet-stream").sendFile(pathToUpdateBin);
   } else


### PR DESCRIPTION
This pull request will add BLE OTA Updates, removing the use of react-native-wifi-reborn, along with the use of a WiFi AP + http server on the MCU side.

The OTA Update will now take place over BLE, over either 1M or 2M (preferred if possible). 
The phone will let the MCU know that there is an available update, which will then let the MCU decide if the user needs to move closer or not, depending on the corresponding RSSI values. 
Then phone will then start the transmission of the bin file over a specified characteristic, likely replacing the use that the current `otaUpdateChar` and corresponding uuid. This will need to take place in many sections, including a start transmission flag, body chunk(s), and an end transmission flag. 
Additionally, this char can stay as notify and write, as the MCU will be able to noitfy the user if anything fails for any reason, whether it be data lost in transmission, or a broken bin file which would brick the device. 

Additionally in this PR, #43 is solved, allowing reduction in # of calls to update server.