### PR TITLE
fix: reset quick links to install defaults

### DIFF
--- a/openwink-app/Components/EditQuickLinksModal.tsx
+++ b/openwink-app/Components/EditQuickLinksModal.tsx
@@ -113,16 +113,19 @@ interface IEditQuickLinksModal {
   visible: boolean;
   close: () => void;
   initialLinks: (QuickLink)[];
+  defaultLinks: (QuickLink)[];
   onUpdateLinks: (updatedLinks: (QuickLink)[]) => void;
 }
 
 export function EditQuickLinksModal({
   close,
+  defaultLinks,
   initialLinks,
   onUpdateLinks,
   visible,
 }: IEditQuickLinksModal) {
   const mappedInitialLinks = useMemo(() => initialLinks.map(l => l.title), [initialLinks]);
+  const mappedDefaultLinks = useMemo(() => defaultLinks.map(l => l.title), [defaultLinks]);
 
   const { colorTheme, theme } = useColorTheme();
 
@@ -163,8 +166,8 @@ export function EditQuickLinksModal({
     }
   }
 
-  const setInitialValues = () => {
-    const mappedLinks = ROUTES.map(r => mappedInitialLinks.includes(r.title) ? { ...r, visible: true } : r);
+  const setLinkValues = (visibleTitles: string[]) => {
+    const mappedLinks = ROUTES.map(r => visibleTitles.includes(r.title) ? { ...r, visible: true } : r);
     const visible = mappedLinks.filter(r => r.visible);
     const hidden = mappedLinks.filter(r => !r.visible);
 
@@ -172,9 +175,9 @@ export function EditQuickLinksModal({
     setFilteredLinks([...visible, ...hidden]);
   }
 
-  useEffect(() => setInitialValues(), []);
+  useEffect(() => setLinkValues(mappedInitialLinks), [mappedInitialLinks]);
 
-  const resetToStart = () => setInitialValues();
+  const resetToStart = () => setLinkValues(mappedDefaultLinks);
   const __saveLinksOnClose = () => {
     onUpdateLinks(allLinks.filter(l => l.visible).map(l => ({ icon: l.icon, navigation: l.navigation, title: l.title })));
     close();

--- a/openwink-app/Pages/Home/Home.tsx
+++ b/openwink-app/Pages/Home/Home.tsx
@@ -404,6 +404,7 @@ export function Home() {
       <EditQuickLinksModal
         close={() => setQuickLinksModalVisible(false)}
         visible={quickLinksModalVisible}
+        defaultLinks={QuickLinksStore.getDefaultLinks()}
         initialLinks={quickLinks}
         onUpdateLinks={(updatedLinks) => updateQuickLinks(updatedLinks)}
       />

--- a/openwink-app/Storage/QuickLinksStore.ts
+++ b/openwink-app/Storage/QuickLinksStore.ts
@@ -25,9 +25,13 @@ const DEFAULTS: QuickLink[] = [
 ]
 export abstract class QuickLinksStore {
 
+  static getDefaultLinks(): QuickLink[] {
+    return DEFAULTS.map(link => ({ ...link, navigation: { ...link.navigation } }));
+  }
+
   static getLinks(): QuickLink[] {
     const linksFromStorage = Storage.getString(QUICKLINKS_KEY);
-    if (!linksFromStorage) return DEFAULTS;
+    if (!linksFromStorage) return QuickLinksStore.getDefaultLinks();
 
     const parsed = JSON.parse(linksFromStorage);
     return parsed as QuickLink[];


### PR DESCRIPTION
## Summary
- add an explicit default quick links accessor
- reset the edit modal to the install-default quick links instead of the current selection
- keep the existing saved-link flow unchanged when closing the modal

Closes #114.

## Validation
- `npm ci`
- `npx tsc --noEmit`
- `git diff --check`

Note: `npm ci` reports existing dependency audit warnings.