### PR TITLE
Hide pairing key by default

### DIFF
--- a/openwink-app/Pages/Settings/Information.tsx
+++ b/openwink-app/Pages/Settings/Information.tsx
@@ -50,6 +50,7 @@ export function Information() {
 
   const bottomSheetRef = useRef<BottomSheet>(null);
   const [displayedCommand, setDisplayedCommand] = useState(null as CommandOutput | null);
+  const [pairingKeyVisible, setPairingKeyVisible] = useState(false);
 
   const headlightStatus = (connected: boolean, status: number) => (
     connected ? (
@@ -64,8 +65,10 @@ export function Information() {
     scanning ? "Scanning" : connecting ? "Connecting" : connected ? "Connected" : "Not Connected"
   );
 
+  const pairingKey = getDevicePasskey();
+  const displayedPairingKey = pairingKeyVisible || pairingKey === "Not Paired" ? pairingKey : "[Hidden]";
+
   const appInfo = {
-    "Pairing Key": getDevicePasskey(),
     "Application Version": `v${Application.nativeApplicationVersion}`,
     "Application Theme": ColorTheme.themeNames[themeName],
   };
@@ -132,9 +135,59 @@ export function Information() {
       />
 
       <ScrollView contentContainerStyle={theme.infoContainer}>
+        <View style={theme.infoBoxOuter}>
+          <Text style={theme.infoBoxOuterText}>
+            App Info
+          </Text>
+
+          <View style={theme.infoBoxInner}>
+            <View style={theme.infoBoxInnerContentView}>
+              <Text style={[theme.infoBoxInnerContentText, { opacity: 0.6 }]}>
+                Pairing Key
+              </Text>
+
+              <Press
+                accessibilityRole="button"
+                accessibilityLabel={pairingKeyVisible ? "Hide pairing key" : "Show pairing key"}
+                hitSlop={8}
+                onPress={() => setPairingKeyVisible((visible) => !visible)}
+                style={{ flexDirection: "row", alignItems: "center", columnGap: 8 }}
+              >
+                {
+                  ({ pressed }) => (
+                    <>
+                      <Text style={theme.infoBoxInnerContentText}>
+                        {displayedPairingKey}
+                      </Text>
+                      <IonIcons
+                        name={pairingKeyVisible ? "eye-off-outline" : "eye-outline"}
+                        size={18}
+                        color={pressed ? colorTheme.buttonColor : colorTheme.textColor}
+                      />
+                    </>
+                  )
+                }
+              </Press>
+            </View>
+
+            {Object.keys(appInfo).map((key) => (
+              <View
+                style={theme.infoBoxInnerContentView}
+                key={key}
+              >
+                <Text style={[theme.infoBoxInnerContentText, { opacity: 0.6 }]}>
+                  {key}
+                </Text>
+
+                <Text style={theme.infoBoxInnerContentText}>
+                  {appInfo[key as keyof typeof appInfo]}
+                </Text>
+              </View>
+            ))}
+          </View>
+        </View>
 
         {[
-          { title: "App Info", data: appInfo },
           { title: "Module Info", data: deviceInfo },
           { title: "Module Settings", data: deviceSettings },
         ].map((section) => (


### PR DESCRIPTION
## Description

Hides the pairing key on the System Info page by default and adds an eye icon toggle so users can reveal it only when needed.

## Changes

- Moves the App Info section into `Information.tsx` so the Pairing Key row can be interactive.
- Shows `[Hidden]` for paired devices until the user taps the eye icon.
- Keeps `Not Paired` visible because it is not sensitive.
- Adds accessibility labels for the show/hide action.

## Closes

Closes #125

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Screenshots/Demo

Not included. This is a small display-state change in the existing System Info page.

## Testing

- `npm ci --ignore-scripts`
- `git diff --check`
- `npx tsc --noEmit --pretty false`

TypeScript currently fails on existing errors outside this change:

- `Pages/Home/CreateCustomCommands/ModifyView.tsx(121,15): error TS2554`
- `Plugins/WithDynamicSplashTheme.ts(192,25): error TS7053`
- `Plugins/WithDynamicSplashTheme.ts(206,12): error TS7006`

No TypeScript errors were reported for `Pages/Settings/Information.tsx`.