### PR TITLE
fix: Pairing Key Display

### DIFF
--- a/openwink-app/Pages/Settings/Information.tsx
+++ b/openwink-app/Pages/Settings/Information.tsx
@@ -17,7 +17,7 @@ import {
   buttonBehaviorMap
 } from "../../helper/Constants";
 import { AutoConnectStore, CustomCommandStore, CustomOEMButtonStore, CustomWaveStore, FirmwareStore, HeadlightOrientationStore, ORIENTATION, ThemeStore } from "../../Storage";
-import { ButtonBehaviors, CommandOutput, Presses } from "../../helper/Types";
+import { ButtonBehaviors, CommandOutput, CustomButtonAction, Presses } from "../../helper/Types";
 import { useColorTheme } from "../../hooks/useColorTheme";
 import { useBleMonitor } from "../../Providers/BleMonitorProvider";
 import { useBleConnection } from "../../Providers/BleConnectionProvider";
@@ -89,20 +89,8 @@ export function Information() {
     "Press Interval": `${buttonDelay} ms`,
   };
 
-  const [rawButtonActions, setRawButtonActions] = useState([] as { numberPresses: Presses; behavior: ButtonBehaviors | CommandOutput; }[]);
-  const buttonActions = useMemo(() => rawButtonActions.map(action => {
-    if (typeof action.behavior === "string")
-      return {
-        behaviorHumanReadable: action.behavior,
-        presses: action.numberPresses,
-        behavior: buttonBehaviorMap[action.behavior],
-      }
-    else
-      return {
-        customCommand: action.behavior,
-        presses: action.numberPresses,
-      }
-  }).sort((a, b) => a.presses - b.presses), [rawButtonActions]);
+  const [rawButtonActions, setRawButtonActions] = useState([] as CustomButtonAction[]);
+  const buttonActions = useMemo(() => rawButtonActions.sort((a, b) => a.presses - b.presses), [rawButtonActions]);
 
   const [customCommands, setCustomCommands] = useState([] as CommandOutput[]);
 

--- a/openwink-app/Pages/Settings/Information.tsx
+++ b/openwink-app/Pages/Settings/Information.tsx
@@ -64,8 +64,11 @@ export function Information() {
     scanning ? "Scanning" : connecting ? "Connecting" : connected ? "Connected" : "Not Connected"
   );
 
+  const pairingKey = getDevicePasskey();
+  // const pairingKey = "Not Paired"
+  const [showPairingKey, setShowPairingKey] = useState(false);
+
   const appInfo = {
-    "Pairing Key": getDevicePasskey(),
     "Application Version": `v${Application.nativeApplicationVersion}`,
     "Application Theme": ColorTheme.themeNames[themeName],
   };
@@ -121,8 +124,70 @@ export function Information() {
 
       <ScrollView contentContainerStyle={theme.infoContainer}>
 
+
+        <View style={theme.infoBoxOuter}>
+
+          <Text style={theme.infoBoxOuterText}>
+            App Info
+          </Text>
+
+
+
+          <View style={theme.infoBoxInner}>
+
+            <View style={theme.infoBoxInnerContentView}>
+              <Text style={[theme.infoBoxInnerContentText, { opacity: 0.6 }]}>
+                Pairing Key
+              </Text>
+              <View style={{
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "center",
+                columnGap: 10,
+              }}>
+
+                <Text style={[theme.infoBoxInnerContentText, { fontSize: showPairingKey ? 16 : 17 }]}>
+                  {
+                    pairingKey === "Not Paired" ? "Not Paired" : showPairingKey ? pairingKey : "[ Key Hidden ]"
+                  }
+                </Text>
+                {
+                  pairingKey !== "Not Paired" ? (
+                    <Press hitSlop={15} onPress={() => setShowPairingKey(!showPairingKey)}>
+                      {({ pressed }) => (
+                        <IonIcons
+                          style={{ marginTop: 3 }}
+                          color={pressed ? colorTheme.buttonColor : colorTheme.headerTextColor}
+                          name={showPairingKey ? "eye-off-outline" : "eye-outline"}
+                          size={20}
+                        />
+                      )}
+                    </Press>
+                  ) : <></>
+                }
+              </View>
+            </View>
+
+            {Object.keys(appInfo).map((key) => (
+              <View
+                style={theme.infoBoxInnerContentView}
+                key={key}
+              >
+                <Text style={[theme.infoBoxInnerContentText, { opacity: 0.6 }]}>
+                  {key}
+                </Text>
+
+                <Text style={theme.infoBoxInnerContentText}>
+                  {appInfo[key as keyof typeof appInfo]}
+                </Text>
+              </View>
+            ))}
+          </View>
+
+        </View>
+
+
         {[
-          { title: "App Info", data: appInfo },
           { title: "Module Info", data: deviceInfo },
           { title: "Module Settings", data: deviceSettings },
         ].map((section) => (


### PR DESCRIPTION
## Description
Adds hidden pairing key display by default, with an option to display the unique pairing key for the device.

## Changes
- Adds a toggle to enable and disable the display of the apps pairing key.
- When in an unpaired state, the toggle is not present, simply displaying "Not Paired"
- Fixes a display bug in the info screen from the PR #130 

## Closes
Closes #125 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Screenshots/Demo
<img width="200" alt="image" src="https://github.com/user-attachments/assets/cc9d3e9c-38e6-4031-87d7-e77e39b1f3d2" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/77c661d9-bddc-4441-ad6e-56253c1ba0d1" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/f6ce8c85-ff2b-442a-a74d-ea5667d66b58" />

----
Below is the old display bug which was fixed in this PR.
<img width="200" alt="image" src="https://github.com/user-attachments/assets/a99797ea-136e-4d03-a746-302eb652e8cc" />


## Testing
N/A - shown in demo images above.